### PR TITLE
fix: add connectionRetryTimeout in attaching to an existing session

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -454,6 +454,9 @@ export function newSession (caps, attachSessId = null) {
         // assume the device is mobile so that Appium protocols are included
         // in the userPrototype.
         serverOpts.isMobile = true;
+        // Need to set connectionRetryTimeout as same as the new session request.
+        // TODO: make configurable?
+        serverOpts.connectionRetryTimeout = 120000;
         driver = await Web2Driver.attachToSession(attachSessId, serverOpts);
         driver._isAttachedSession = true;
       } else {


### PR DESCRIPTION
As same as appium-inspector's original fix to not include some diffs.